### PR TITLE
Master -  time acounting checkboxes for MassEntry action

### DIFF
--- a/Kernel/Output/HTML/Templates/Standard/AgentTimeAccountingEdit.tt
+++ b/Kernel/Output/HTML/Templates/Standard/AgentTimeAccountingEdit.tt
@@ -107,9 +107,9 @@ $('#NavigationSelect').bind('click', function(){
                 <div id="MassEntryConfirmDialog" class="Hidden">
                     <h2>[% Translate("Please choose the reason for your absence for the selected days") | html %].</h2>
                     <ul id="MassEntryConfirmRadio">
-                        <li><input type="radio" name="LeaveDay" id="ConfirmLeaveDay" /><label for="ConfirmLeaveDay">[% Translate("On vacation") | html %]</label></li>
-                        <li><input type="radio" name="Sick" id="ConfirmSick" /><label for="ConfirmSick">[% Translate("On sick leave") | html %]</label></li>
-                        <li><input type="radio" name="Overtime" id="ConfirmOvertime" /><label for="ConfirmOvertime">[% Translate("On overtime leave") | html %]</label></li>
+                        <li><input type="radio" data-absence="LeaveDay" name="Absence[]" id="ConfirmLeaveDay" /><label for="ConfirmLeaveDay">[% Translate("On vacation") | html %]</label></li>
+                        <li><input type="radio" data-absence="Sick" name="Absence[]" id="ConfirmSick" /><label for="ConfirmSick">[% Translate("On sick leave") | html %]</label></li>
+                        <li><input type="radio" data-absence="Overtime" name="Absence[]" id="ConfirmOvertime" /><label for="ConfirmOvertime">[% Translate("On overtime leave") | html %]</label></li>
                     </ul>
                 </div>
 [% WRAPPER JSOnDocumentComplete %]
@@ -295,7 +295,7 @@ $('#NavigationSelect').bind('click', function(){
                         </tbody>
                     </table>
 [% RenderBlockStart("OtherTimes") %]
-                    <div class="SpacingTop">
+                    <div class="SpacingTop Absence">
                         <input type="checkbox" value="1" id="LeaveDay" name="LeaveDay" title="[% Translate("On vacation") | html %]" class="[% Data.LeaveDayInvalid %]" [% Data.LeaveDay %] />
                         <label for="LeaveDay">[% Translate("On vacation") | html %]</label>
                         <div id="LeaveDayServerError" class="TooltipErrorMessage">

--- a/Kernel/Output/HTML/Templates/Standard/AgentTimeAccountingEdit.tt
+++ b/Kernel/Output/HTML/Templates/Standard/AgentTimeAccountingEdit.tt
@@ -107,9 +107,9 @@ $('#NavigationSelect').bind('click', function(){
                 <div id="MassEntryConfirmDialog" class="Hidden">
                     <h2>[% Translate("Please choose the reason for your absence for the selected days") | html %].</h2>
                     <ul id="MassEntryConfirmRadio" class="MassAbsence">
-                        <li><input type="checkbox" name="LeaveDay" id="ConfirmLeaveDay"  /><label for="ConfirmLeaveDay">[% Translate("On vacation") | html %]</label></li>
-                        <li><input type="checkbox" name="Sick" id="ConfirmSick"  /><label for="ConfirmSick">[% Translate("On sick leave") | html %]</label></li>
-                        <li><input type="checkbox" name="Overtime" id="ConfirmOvertime"  /><label for="ConfirmOvertime">[% Translate("On overtime leave") | html %]</label></li>
+                        <li><input type="checkbox" name="LeaveDay" id="ConfirmLeaveDay" /><label for="ConfirmLeaveDay">[% Translate("On vacation") | html %]</label></li>
+                        <li><input type="checkbox" name="Sick" id="ConfirmSick" /><label for="ConfirmSick">[% Translate("On sick leave") | html %]</label></li>
+                        <li><input type="checkbox" name="Overtime" id="ConfirmOvertime" /><label for="ConfirmOvertime">[% Translate("On overtime leave") | html %]</label></li>
                     </ul>
                 </div>
 [% WRAPPER JSOnDocumentComplete %]

--- a/Kernel/Output/HTML/Templates/Standard/AgentTimeAccountingEdit.tt
+++ b/Kernel/Output/HTML/Templates/Standard/AgentTimeAccountingEdit.tt
@@ -106,10 +106,10 @@ $('#NavigationSelect').bind('click', function(){
                 </form>
                 <div id="MassEntryConfirmDialog" class="Hidden">
                     <h2>[% Translate("Please choose the reason for your absence for the selected days") | html %].</h2>
-                    <ul id="MassEntryConfirmRadio">
-                        <li><input type="radio" data-absence="LeaveDay" name="Absence[]" id="ConfirmLeaveDay" /><label for="ConfirmLeaveDay">[% Translate("On vacation") | html %]</label></li>
-                        <li><input type="radio" data-absence="Sick" name="Absence[]" id="ConfirmSick" /><label for="ConfirmSick">[% Translate("On sick leave") | html %]</label></li>
-                        <li><input type="radio" data-absence="Overtime" name="Absence[]" id="ConfirmOvertime" /><label for="ConfirmOvertime">[% Translate("On overtime leave") | html %]</label></li>
+                    <ul id="MassEntryConfirmRadio" class="MassAbsence">
+                        <li><input type="checkbox" name="LeaveDay" id="ConfirmLeaveDay"  /><label for="ConfirmLeaveDay">[% Translate("On vacation") | html %]</label></li>
+                        <li><input type="checkbox" name="Sick" id="ConfirmSick"  /><label for="ConfirmSick">[% Translate("On sick leave") | html %]</label></li>
+                        <li><input type="checkbox" name="Overtime" id="ConfirmOvertime"  /><label for="ConfirmOvertime">[% Translate("On overtime leave") | html %]</label></li>
                     </ul>
                 </div>
 [% WRAPPER JSOnDocumentComplete %]

--- a/var/httpd/htdocs/js/TimeAccounting.Agent.EditTimeRecords.js
+++ b/var/httpd/htdocs/js/TimeAccounting.Agent.EditTimeRecords.js
@@ -336,11 +336,8 @@ TimeAccounting.Agent.EditTimeRecords = (function (TargetNS) {
         // initiate period calculation
         InitPeriodCalculation();
 
-        // Select only one checkbox in the group 'Absence'
-        $(".Absence input:checkbox").click(function () {
-            $(".Absence input:checkbox").prop("checked", false);
-            $(this).prop("checked", true);
-        });
+        // Select only one checkbox in the with class 'Absence'
+        TargetNS.CheckGroupSelect('.Absence');
     };
 
 
@@ -370,17 +367,17 @@ TimeAccounting.Agent.EditTimeRecords = (function (TargetNS) {
                 {
                     Label: Language.Submit,
                     Function: function () {
-                        var $SelectedRadio = $('#MassEntryConfirmRadio li input:radio:checked'),
+                        var $SelectedCheck = $('#MassEntryConfirmRadio li input:checkbox:checked'),
                             AbsenceReason,
                             CollectedDates = '';
 
-                        if (!$SelectedRadio.length) {
+                        if (!$SelectedCheck.length) {
                             alert(Language.MsgAbsenceReason);
                             return false;
                         }
 
                         // set absence reason
-                        AbsenceReason = $SelectedRadio.data('absence');
+                        AbsenceReason = $SelectedCheck.attr('name');
                         if (AbsenceReason === 'LeaveDay') {
                             $('#MassEntry input[name=LeaveDay]').val(1);
                         }
@@ -422,7 +419,25 @@ TimeAccounting.Agent.EditTimeRecords = (function (TargetNS) {
                     }
                 }
             ]);
+
+            // Select only one checkbox in the with class 'MassAbsence'
+            TargetNS.CheckGroupSelect('.MassAbsence');
             return false;
+        });
+    };
+
+    /**
+     * @name CheckGroupSelect
+     * @memberof TimeAccounting.Agent.EditTimeRecords
+     * @function
+     * @param {String} Class - class where there is group of checkboxes
+     * @description
+     *      This function select only one checkbox in a group with class 'Class'
+     */
+    TargetNS.CheckGroupSelect = function(Class) {
+        $(Class + " input:checkbox").click(function () {
+            $(Class + " input:checkbox").prop("checked", false);
+            $(this).prop("checked", true);
         });
     };
 

--- a/var/httpd/htdocs/js/TimeAccounting.Agent.EditTimeRecords.js
+++ b/var/httpd/htdocs/js/TimeAccounting.Agent.EditTimeRecords.js
@@ -335,6 +335,12 @@ TimeAccounting.Agent.EditTimeRecords = (function (TargetNS) {
 
         // initiate period calculation
         InitPeriodCalculation();
+
+        // Select only one checkbox in the group 'Absence'
+        $(".Absence input:checkbox").click(function () {
+            $(".Absence input:checkbox").prop("checked", false);
+            $(this).prop("checked", true);
+        });
     };
 
 
@@ -374,7 +380,7 @@ TimeAccounting.Agent.EditTimeRecords = (function (TargetNS) {
                         }
 
                         // set absence reason
-                        AbsenceReason = $SelectedRadio.attr('name');
+                        AbsenceReason = $SelectedRadio.data('absence');
                         if (AbsenceReason === 'LeaveDay') {
                             $('#MassEntry input[name=LeaveDay]').val(1);
                         }


### PR DESCRIPTION
Hi @carlosfrodriguez 

As you suggested in https://github.com/OTRS/TimeAccounting/pull/14 I implemented checkboxes for MassEntry action in AgentTimeAccountingEdit screen.
I have made new PR in reason of easier testing the both solution. You can compare them and choose the one which you prefer. 
To be honest I prefer solution with radio button. I think that radio button is better for such situation where we want select one item of group options on the form. However I also think that checkboxes is OK for single time record edit. It is slight difference and maybe I was get used to on the layout with radio button and checkboxes during the testing.

Please let me know which one is better for you, and if you have any suggestions for further improvement. 

Regards
Zoran