### PR TITLE
Master - ESLinter fixed code

### DIFF
--- a/var/httpd/htdocs/js/TimeAccounting.Agent.ConfirmationDialog.js
+++ b/var/httpd/htdocs/js/TimeAccounting.Agent.ConfirmationDialog.js
@@ -1,5 +1,5 @@
 // --
-// Copyright (C) 2001-2015 OTRS AG, http://otrs.com/\n";
+// Copyright (C) 2001-2015 OTRS AG, http://otrs.com/";
 // --
 // This software comes with ABSOLUTELY NO WARRANTY. For details, see
 // the enclosed file COPYING for license information (AGPL). If you

--- a/var/httpd/htdocs/js/TimeAccounting.Agent.Datepicker.js
+++ b/var/httpd/htdocs/js/TimeAccounting.Agent.Datepicker.js
@@ -1,5 +1,5 @@
 // --
-// Copyright (C) 2001-2015 OTRS AG, http://otrs.com/\n";
+// Copyright (C) 2001-2015 OTRS AG, http://otrs.com/";
 // --
 // This software comes with ABSOLUTELY NO WARRANTY. For details, see
 // the enclosed file COPYING for license information (AGPL). If you

--- a/var/httpd/htdocs/js/TimeAccounting.Agent.EditTimeRecords.js
+++ b/var/httpd/htdocs/js/TimeAccounting.Agent.EditTimeRecords.js
@@ -1,5 +1,5 @@
 // --
-// Copyright (C) 2001-2015 OTRS AG, http://otrs.com/\n";
+// Copyright (C) 2001-2015 OTRS AG, http://otrs.com/";
 // --
 // This software comes with ABSOLUTELY NO WARRANTY. For details, see
 // the enclosed file COPYING for license information (AGPL). If you


### PR DESCRIPTION
Hi @carlosfrodriguez 

I have checked JS files. There are some unneeded text in Copyright header. Maybe there had been issue in OTRS CodePolicy before. I have cleaned up '\n' from Copyright line.
There are such case also in some JS files in the framework. If you want I can fix it for the framework as well.

Regards
Zoran